### PR TITLE
Added --silent flag to silence console logging.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -6,12 +6,13 @@ const packageJson = require("../package.json");
 sade("react-scanner", true)
   .version(packageJson.version)
   .describe(packageJson.description)
+  .option("-s, --silent", "Silence logging")
   .option("-c, --config", "Path to config file")
   .example("-c /path/to/react-scanner.config.js")
   .action((options) => {
     const configPath = path.resolve(process.cwd(), options.config);
     const configDir = path.dirname(configPath);
     const config = require(configPath);
-    run(config, configDir, "cli");
+    run(config, configDir, "cli", options.silent);
   })
   .parse(process.argv);

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -209,4 +209,29 @@ Index("no files found", async () => {
   }
 });
 
+Index("silent - no error", async () => {
+  const { exitCode, stdout } = await execa("./bin/react-scanner", [
+    "-c",
+    "./test/configs/noProcessors.config.js",
+    "--silent",
+  ]);
+  const { firstLine, restOutput } = parseStdout(stdout);
+  assert.is(exitCode, 0);
+  assert.ok(/^$/.test(firstLine));
+  assert.ok(/^$/, restOutput);
+});
+
+Index("silent - error", async () => {
+  try {
+    await execa("./bin/react-scanner", [
+      "-c",
+      "./test/configs/noFilesFound.config.js",
+      "--silent",
+    ]);
+  } catch ({ exitCode, stderr }) {
+    assert.is(exitCode, 1);
+    assert.is(stderr, "");
+  }
+});
+
 Index.run();

--- a/src/run.js
+++ b/src/run.js
@@ -19,6 +19,7 @@ async function run({
   crawlFrom,
   startTime,
   method = "cli",
+  silent,
 }) {
   const rootDir = config.rootDir || configDir;
   const globs = config.globs || DEFAULT_GLOBS;
@@ -30,7 +31,9 @@ async function run({
     .sync();
 
   if (files.length === 0) {
-    console.error(`No files found to scan.`);
+    if (!silent) {
+      console.error(`No files found to scan.`);
+    }
     process.exit(1);
   }
 
@@ -61,12 +64,14 @@ async function run({
 
   const endTime = process.hrtime.bigint();
 
-  // eslint-disable-next-line no-console
-  console.log(
-    `Scanned ${pluralize(files.length, "file")} in ${
-      Number(endTime - startTime) / 1e9
-    } seconds`
-  );
+  if (!silent) {
+    // eslint-disable-next-line no-console
+    console.log(
+      `Scanned ${pluralize(files.length, "file")} in ${
+        Number(endTime - startTime) / 1e9
+      } seconds`
+    );
+  }
 
   const processors =
     config.processors && config.processors.length > 0
@@ -82,8 +87,10 @@ async function run({
 
     switch (dest) {
       case "stdout": {
-        // eslint-disable-next-line no-console
-        console.log(dataStr);
+        if (!silent) {
+          // eslint-disable-next-line no-console
+          console.log(dataStr);
+        }
         break;
       }
       case "return": {

--- a/src/scanner.js
+++ b/src/scanner.js
@@ -4,7 +4,7 @@ const { validateConfig } = require("./utils");
 const runScan = require("./run");
 
 const scanner = {
-  run: async function run(config, configDir, method = "programmatic") {
+  run: async function run(config, configDir, method = "programmatic", silent) {
     const { crawlFrom, errors } = validateConfig(config, configDir);
 
     if (errors.length === 0) {
@@ -14,13 +14,16 @@ const scanner = {
         crawlFrom,
         startTime,
         method: method,
+        silent,
       });
     } else {
-      console.error(`Config errors:`);
+      if (!silent) {
+        console.error(`Config errors:`);
 
-      errors.forEach((error) => {
-        console.error(`- ${error}`);
-      });
+        errors.forEach((error) => {
+          console.error(`- ${error}`);
+        });
+      }
 
       process.exit(1);
     }


### PR DESCRIPTION
Building a cli tool for some stuff at work, and the output is messing with our output. Added a simple `--silent` flag to silence any of the logging. Not sure your exact thoughts on `--silent` suppressing the `console.error`, I've seen libs do either silence everything or have a separate log-level and a silence-errors option.

Works for what I need, but if you have any feedback or suggestions on something a little more flexible, I'm all ears. 