### PR TITLE
fix: update picomatch dep

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "dset": "3.1.4",
         "fdir": "5.2.0",
         "is-plain-object": "5.0.0",
-        "picomatch": "2.3.1",
+        "picomatch": "^2.3.2",
         "sade": "1.8.1",
         "typescript": "5.6.2"
       },
@@ -2656,9 +2656,10 @@
       }
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "license": "MIT",
       "engines": {
         "node": ">=8.6"
       },

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "dset": "3.1.4",
     "fdir": "5.2.0",
     "is-plain-object": "5.0.0",
-    "picomatch": "2.3.1",
+    "picomatch": "2.3.2",
     "sade": "1.8.1",
     "typescript": "5.6.2"
   },
@@ -40,10 +40,7 @@
     "type": "git",
     "url": "https://github.com/moroshko/react-scanner"
   },
-  "files": [
-    "bin",
-    "src/**/!(*.test).@(js|json)"
-  ],
+  "files": ["bin", "src/**/!(*.test).@(js|json)"],
   "engines": {
     "node": ">=14.x"
   },


### PR DESCRIPTION
This pull request makes a minor update to the `package.json` file, including a dependency version bump and a small formatting change.

- Dependency updates:
  * Upgraded the `picomatch` dependency from version `2.3.1` to `2.3.2` to include the latest bug fixes and improvements.

- Formatting changes:
  * Reformatted the `files` array to a single line for consistency and readability. No functional changes were made.
  
Fixes the issue with `npm audit` flag security concerns (and the security concerns themself).
